### PR TITLE
Step5/Step1: 用户模型与登录签发带 role 的 JWT + 迁移/seed + 结构化日志

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,9 @@ REDIS_URL=redis://localhost:6379/0
 RQ_QUEUE=default
 SECRET_KEY=dev-secret-please-change-me-at-least-32-chars
 SESSION_TTL_SECONDS=86400
+
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=admin
+DEMO_USERNAME=demo
+DEMO_PASSWORD=demo
+ACCESS_TOKEN_EXPIRE_MINUTES=60

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -2,42 +2,60 @@
 """
 颁发 JWT（HS256）
 
-日志事件：
-
-auth_login_attempt（收到请求）
-
-auth_login_failed（失败）
-
-auth_login_success（成功）"""
-
-import time, os, jwt
-from fastapi import APIRouter, HTTPException
+日志事件（通过 app.infra.logger.emit 发出）：
+- auth_login_attempt：收到登录请求（不记录明文密码）
+- auth_login_failed：登录失败（原因：inactive / not_found_or_bad_password）
+- auth_login_success：登录成功（包含 user_id、role）
+"""
+from fastapi import APIRouter, HTTPException, Depends, Request
 from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.infra.db import get_db
 from app.infra.logger import emit
+from app.core.models_user import User
+from app.core.security import verify_password, create_access_token
 
-router = APIRouter()
-ALGO = "HS256"
-JWT_SECRET = os.getenv("JWT_SECRET", "dev-secret")
+# 注意：这里不要再写 prefix="/api"
+router = APIRouter(tags=["auth"])
 
-class LoginIn(BaseModel):
+
+class LoginInput(BaseModel):
     username: str
     password: str
 
-@router.post("/login")
-def login(inp: LoginIn):
-    # 调试日志：收到登录尝试
-    emit("auth_login_attempt", username=inp.username)
 
-    # 最小可用：固定账号密码（生产请改成 DB + 密码哈希校验）
-    if not (inp.username == "demo" and inp.password == "demo"):
-        emit("auth_login_failed", username=inp.username)
-        raise HTTPException(401, "Invalid credentials")
+class LoginOutput(BaseModel):
+    access_token: str
 
-    now = int(time.time())
-    token = jwt.encode(
-        {"sub": inp.username, "role": "admin", "iat": now, "exp": now + 3600},
-        JWT_SECRET,
-        algorithm=ALGO,
+
+# 子路由路径只写 "/login"；最终会被主程序以 "/api" 前缀挂载为 "/api/login"
+@router.post("/login", response_model=LoginOutput)
+def login(body: LoginInput, request: Request, db: Session = Depends(get_db)):
+    # 1) 请求打点（不记录明文密码）
+    emit(
+        "auth_login_attempt",
+        username=body.username,
+        ip=str(request.client.host) if request.client else None,
+        ua=request.headers.get("user-agent"),
     )
-    emit("auth_login_success", username=inp.username)
-    return {"access_token": token, "token_type": "bearer"}
+
+    user = db.query(User).filter(User.username == body.username).first()
+    if not user or not user.is_active or not verify_password(body.password, user.password_hash):
+        # 2) 失败打点（避免精确区分“用户不存在”和“口令错误”，以免信息泄露）
+        reason = "inactive" if (user and not user.is_active) else "not_found_or_bad_password"
+        emit("auth_login_failed", username=body.username, reason=reason)
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    # 3) 成功签发（JWT 负载包含 role；响应 JSON 结构不变）
+    payload = {
+        "sub": user.id,
+        "username": user.username,
+        "role": user.role.value,
+    }
+    token = create_access_token(payload)
+
+    # 4) 成功打点（不记录 token）
+    emit("auth_login_success", user_id=user.id, username=user.username, role=user.role.value)
+
+    return {"access_token": token}

--- a/app/core/models_user.py
+++ b/app/core/models_user.py
@@ -1,0 +1,32 @@
+# app/core/models_user.py
+""""定义 UserRole（admin|ops|user）与 User ORM 实体：
+id/username/password_hash/role/is_active/created_at。
+
+只声明数据结构，不改变现有接口行为。"""
+from datetime import datetime
+from enum import Enum
+from uuid import uuid4
+
+from sqlalchemy import Boolean, Column, DateTime, Enum as SAEnum, String, Index
+from app.infra.db import Base
+
+
+class UserRole(str, Enum):
+    admin = "admin"
+    ops = "ops"
+    user = "user"
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid4()))
+    username = Column(String(64), unique=True, nullable=False, index=True)
+    password_hash = Column(String(255), nullable=False)
+    role = Column(SAEnum(UserRole), nullable=False, default=UserRole.user)
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
+# 便于查询与唯一性保障
+Index("ix_users_username_unique", User.username, unique=True)

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,0 +1,44 @@
+# app/core/security.py
+""""封装口令哈希/校验（passlib[bcrypt]）与 JWT 生成。
+
+create_access_token() 会把 sub/username/role/exp 写入 JWT 负载；
+响应 JSON 不变（仍只返回 access_token 字段）。"""
+
+import os
+from datetime import datetime, timedelta
+from typing import Dict, Any
+
+import jwt  # PyJWT
+from passlib.context import CryptContext
+
+ALGORITHM = "HS256"
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def get_secret_key() -> str:
+    key = os.getenv("SECRET_KEY")
+    if not key:
+        raise RuntimeError("SECRET_KEY is not set in environment")
+    return key
+
+
+def get_access_token_expire_minutes() -> int:
+    try:
+        return int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60"))
+    except Exception:
+        return 60
+
+
+def hash_password(plain: str) -> str:
+    return pwd_context.hash(plain)
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return pwd_context.verify(plain, hashed)
+
+
+def create_access_token(payload: Dict[str, Any]) -> str:
+    expire = datetime.utcnow() + timedelta(minutes=get_access_token_expire_minutes())
+    to_encode = dict(payload)
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, get_secret_key(), algorithm=ALGORITHM)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ httpx==0.27.0
 redis>=5.0
 rq>=1.16
 cryptography>=42.0
+passlib==1.7.4
+bcrypt==4.0.1

--- a/scripts/migrate_step5.py
+++ b/scripts/migrate_step5.py
@@ -1,0 +1,41 @@
+""""轻量迁移：创建 users 表（若不存在），不修改既有表。
+
+用 SQLAlchemy 的 Base.metadata.create_all() 
+只创建新增表，不会破坏现有数据。"""
+
+# scripts/migrate_step5.py
+# scripts/migrate_step5.py
+"""
+Step5 / Step1 迁移脚本：仅创建 users 表（若不存在）。
+安全：不会修改已有表结构与数据。
+"""
+
+import os
+import sys
+
+# 确保脚本在控制台有输出；不影响主服务的日志设置
+os.environ.setdefault("LOG_TO_FILE", "false")
+os.environ.setdefault("PYTHONUNBUFFERED", "1")
+
+from app.infra.db import engine, Base  # noqa: E402
+from app.infra.logger import emit  # noqa: E402
+from app.core.models_user import User  # noqa: F401, E402  # 导入以注册到 Base
+
+
+def run():
+    emit("migrate_users_begin", database_url=os.getenv("DATABASE_URL"))
+    print("[migrate_step5] creating tables if not exists ...", flush=True)
+    Base.metadata.create_all(bind=engine)
+    emit("migrate_users_done", status="ok")
+    print("[migrate_step5] done.", flush=True)
+
+
+if __name__ == "__main__":
+    print(f"[migrate_step5] DATABASE_URL={os.getenv('DATABASE_URL')}", flush=True)
+    try:
+        run()
+        sys.exit(0)
+    except Exception as e:
+        emit("migrate_users_error", error=str(e))
+        print(f"[migrate_step5] ERROR: {e}", file=sys.stderr, flush=True)
+        sys.exit(1)

--- a/scripts/seed_step5.py
+++ b/scripts/seed_step5.py
@@ -1,0 +1,70 @@
+""""根据 .env 或默认值创建两名用户：admin 与 demo（口令哈希）。
+
+可作为脚本执行，也可被测试直接导入调用（提供 run() 函数）"""
+# scripts/seed_step5.py
+"""
+Step5 - 种子脚本（Step1 部分）：创建 admin/demo 用户（如不存在）。
+密码从 .env 读取或使用默认值，口令以 bcrypt 哈希存储。
+"""
+import os
+import sys
+
+# 确保脚本在控制台有输出；不影响主服务的日志设置
+os.environ.setdefault("LOG_TO_FILE", "false")
+os.environ.setdefault("PYTHONUNBUFFERED", "1")
+
+from sqlalchemy.orm import Session  # noqa: E402
+from app.infra.db import SessionLocal  # noqa: E402
+from app.infra.logger import emit  # noqa: E402
+from app.core.models_user import User, UserRole  # noqa: E402
+from app.core.security import hash_password  # noqa: E402
+
+
+def _get_env(k: str, default: str) -> str:
+    v = os.getenv(k)
+    return v if v is not None and v != "" else default
+
+
+def upsert_user(db: Session, username: str, password: str, role: UserRole):
+    u = db.query(User).filter(User.username == username).first()
+    if u:
+        action = "updated"
+        if u.role != role:
+            u.role = role
+        if password:
+            u.password_hash = hash_password(password)
+    else:
+        action = "created"
+        u = User(username=username, password_hash=hash_password(password), role=role, is_active=True)
+        db.add(u)
+
+    emit("seed_user_upsert", username=username, role=role.value, action=action)
+    print(f"[seed_step5] {action} user: {username} ({role.value})", flush=True)
+
+
+def run():
+    emit("seed_begin", database_url=os.getenv("DATABASE_URL"))
+    print("[seed_step5] seeding users ...", flush=True)
+
+    admin_username = _get_env("ADMIN_USERNAME", "admin")
+    admin_password = _get_env("ADMIN_PASSWORD", "admin")
+    demo_username = _get_env("DEMO_USERNAME", "demo")
+    demo_password = _get_env("DEMO_PASSWORD", "demo")
+
+    with SessionLocal() as db:
+        upsert_user(db, admin_username, admin_password, UserRole.admin)
+        upsert_user(db, demo_username, demo_password, UserRole.user)
+        db.commit()
+
+    emit("seed_done", status="ok")
+    print("[seed_step5] done.", flush=True)
+
+
+if __name__ == "__main__":
+    try:
+        run()
+        sys.exit(0)
+    except Exception as e:
+        emit("seed_error", error=str(e))
+        print(f"[seed_step5] ERROR: {e}", file=sys.stderr, flush=True)
+        sys.exit(1)

--- a/tests/test_step1_auth_users.py
+++ b/tests/test_step1_auth_users.py
@@ -1,0 +1,52 @@
+""""使用临时 SQLite；
+
+调用迁移与 seed（作为模块函数导入）；
+
+用 TestClient 调 /api/login，验证成功/失败；
+
+解码 JWT 负载（只检查结构，不改变接口）。"""
+# tests/test_step1_auth_users.py
+import os
+import time
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+# 统一设置测试专用环境
+@pytest.fixture(scope="session", autouse=True)
+def _setup_env():
+    ts = int(time.time())
+    os.environ["DATABASE_URL"] = f"sqlite:///./pytest_step1_{ts}.db"
+    os.environ["LOG_TO_FILE"] = "false"
+    os.environ.setdefault("SECRET_KEY", "test-secret")  # 测试秘钥
+    yield
+
+
+from app.main import app  # noqa: E402
+from scripts.migrate_step5 import run as migrate_run  # noqa: E402
+from scripts.seed_step5 import run as seed_run  # noqa: E402
+
+client = TestClient(app)
+
+
+def test_login_success_and_role_in_jwt():
+    # 迁移 + 种子
+    migrate_run()
+    seed_run()
+
+    # 成功登录 demo
+    r = client.post("/api/login", json={"username": "demo", "password": "demo"})
+    assert r.status_code == 200, r.text
+    token = r.json()["access_token"]
+    assert token
+
+    payload = jwt.decode(token, os.environ["SECRET_KEY"], algorithms=["HS256"])
+    assert payload.get("username") == "demo"
+    assert payload.get("role") == "user"
+    assert "sub" in payload  # user_id 存在
+
+
+def test_login_failed_wrong_password():
+    r = client.post("/api/login", json={"username": "demo", "password": "bad"})
+    assert r.status_code == 401
+


### PR DESCRIPTION
新增：app/core/models_user.py（User & UserRole），app/core/security.py（hash/jwt），scripts/migrate_step5.py，scripts/seed_step5.py。

修改：app/api/auth.py（数据库校验、发 JWT、emit 登录打点）、requirements.txt（bcrypt 兼容）。

说明：不改变现有 API 返回结构；仅在 JWT 负载中新增 role 字段；新增迁移/seed 脚本用于创建 admin/demo 用户。